### PR TITLE
Removed code that will create an anomaly while adding an image file

### DIFF
--- a/source/R5T.Aestia.Database/Code/Repositories/DatabaseAnomalyRepository.cs
+++ b/source/R5T.Aestia.Database/Code/Repositories/DatabaseAnomalyRepository.cs
@@ -55,8 +55,6 @@ namespace R5T.Aestia.Database
         {
             await this.ExecuteInContextAsync(async dbContext =>
             {
-                await this.AddOnlyIfNotExistsAsync(anomalyIdentity);
-
                 var anomalyID = await dbContext.GetAnomaly(anomalyIdentity).Select(x => x.ID).SingleAsync();
 
                 // Acquire the AnomalyToImageFileMapping (since there currently can only be one image per anomaly).


### PR DESCRIPTION
Removed code that will create an anomaly while adding an image file if the anomaly doesn't exist already. This is now an exception.